### PR TITLE
DM-26326: Remove obs dependency from ap_verify_testdata and ap_pipe_testdata

### DIFF
--- a/ups/ap_pipe_testdata.table
+++ b/ups/ap_pipe_testdata.table
@@ -1,2 +1,3 @@
-setupRequired(obs_decam)
+# Data cannot be used without obs_decam, but this dependency is omitted to
+# avoid forcing a new download any time obs_decam is rebuilt.
 


### PR DESCRIPTION
This PR removes the sole EUPS dependency from this package.