### PR TITLE
DM-35843: Deprecate and move ap_pipe_testdata to legacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# ap_pipe_testdata
+
+This package provided optional gen2 testdata for ap_pipe, but those tests are not necessary in gen3.
+This package has been deprecated and moved to legacy status.


### PR DESCRIPTION
Adding the deprecation readme before I do the rename/move step.